### PR TITLE
Displaying the state for updating

### DIFF
--- a/Examples/Examples/ESTAccelerometerDemoVC.m
+++ b/Examples/Examples/ESTAccelerometerDemoVC.m
@@ -97,7 +97,7 @@
         }
         else
         {
-            self.activityLabel.text = @"Accelerometer not available";
+            self.activityLabel.text = [NSString stringWithFormat:@"Error:%@", [error localizedDescription]];
             self.activityLabel.textColor = [UIColor redColor];
         }
         

--- a/Examples/Examples/ESTTemperatureDemoVC.m
+++ b/Examples/Examples/ESTTemperatureDemoVC.m
@@ -69,7 +69,7 @@
         }
         else
         {
-            self.activityLabel.text = @"Temerature not available";
+            self.activityLabel.text = [NSString stringWithFormat:@"Error:%@", [error localizedDescription]];
             self.activityLabel.textColor = [UIColor redColor];
         }
     }];

--- a/Examples/Examples/ESTUpdateFirmwareDemoVC.m
+++ b/Examples/Examples/ESTUpdateFirmwareDemoVC.m
@@ -13,7 +13,7 @@
 @property (nonatomic, strong) ESTBeacon *beacon;
 
 //UI properties
-@property (strong, nonatomic) IBOutlet UILabel *connectionStateLabel;
+@property (strong, nonatomic) IBOutlet UILabel *updateStateLabel;
 @property (strong, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicator;
 @property (strong, nonatomic) IBOutlet UILabel *updateProgressLabel;
 
@@ -80,6 +80,7 @@
 
     [self.beacon updateFirmwareWithProgress:^(NSInteger value, NSString *description, NSError *error) {
         
+        selfReference.updateStateLabel.text = description;
         selfReference.updateProgressLabel.text = [NSString stringWithFormat:@"%ld %%", (long)value];
 
     } completion:^(NSError *error) {
@@ -88,12 +89,14 @@
 
         if (!error)
         {
+            selfReference.updateStateLabel.text = @"";
             selfReference.updateProgressLabel.text = @"Updated!";
             selfReference.updateProgressLabel.font = [UIFont boldSystemFontOfSize:50];
         }
         else
         {
             NSLog(@"Update failed.");
+            selfReference.updateStateLabel.text = [error localizedDescription];
             selfReference.updateProgressLabel.text = @"Failed!";
             selfReference.updateProgressLabel.font = [UIFont boldSystemFontOfSize:50];
         }
@@ -103,7 +106,7 @@
 #pragma mark - ESTBeacon Delegate
 - (void)beaconConnectionDidSucceeded:(ESTBeacon *)beacon
 {
-    self.connectionStateLabel.text = @"Connected!";
+    self.updateStateLabel.text = @"Connected!";
     [self.activityIndicator stopAnimating];
     
     //After succesful connection we check if update for our beacon is available.

--- a/Examples/Examples/ESTUpdateFirmwareDemoVC.xib
+++ b/Examples/Examples/ESTUpdateFirmwareDemoVC.xib
@@ -7,8 +7,8 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ESTUpdateFirmwareDemoVC">
             <connections>
                 <outlet property="activityIndicator" destination="VNa-o6-e3D" id="7YN-Ic-Ylm"/>
-                <outlet property="connectionStateLabel" destination="T1z-sQ-IbO" id="Uej-7S-5rC"/>
                 <outlet property="updateProgressLabel" destination="evQ-cE-I7u" id="QJd-EL-1AW"/>
+                <outlet property="updateStateLabel" destination="T1z-sQ-IbO" id="lFP-I9-ccM"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>


### PR DESCRIPTION
Developers need to know the states for updating such as downloading, rebooting, or what kind of errors occurred.
So I changed the labels' role to display the states.
