### PR TITLE
Add button for saving auth credentials.

### DIFF
--- a/Examples/Examples/ESTCloudAuthVC.m
+++ b/Examples/Examples/ESTCloudAuthVC.m
@@ -39,9 +39,9 @@
     [ESTBeaconManager setupAppID:self.appIdField.text andAppToken:self.appTokenField.text];
 }
 
-- (void)dismiss
+- (IBAction)dismiss
 {
-    [self dismissViewControllerAnimated:YES completion:nil];
+    [self.navigationController popToRootViewControllerAnimated:YES];
 }
 
 #pragma mark - TextField delegate

--- a/Examples/Examples/ESTCloudAuthVC.xib
+++ b/Examples/Examples/ESTCloudAuthVC.xib
@@ -28,6 +28,18 @@
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done"/>
                 </textField>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lwU-NK-YP5">
+                    <rect key="frame" x="137" y="163" width="46" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <state key="normal" title="Save">
+                        <color key="titleColor" red="0.49019607843137253" green="0.63137254901960782" blue="0.5490196078431373" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="dismiss" destination="-1" eventType="touchUpInside" id="cce-am-rRx"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="0.94193892050000005" green="0.94193892050000005" blue="0.94193892050000005" alpha="1" colorSpace="calibratedRGB"/>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>


### PR DESCRIPTION
Hello. I was just playing with your examples. It was not obvious for me that clicking back in navigation bar will save my cloud credentials. I added a save button in authorization view. Old behaviour is preserved.
