### PR TITLE
Fixes to example app for iOS 8

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = "ExamplesTests/ExamplesTests-Info.plist";
+				INFOPLIST_FILE = "Examples/Examples-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -496,7 +496,7 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Examples/Examples-Prefix.pch";
-				INFOPLIST_FILE = "ExamplesTests/ExamplesTests-Info.plist";
+				INFOPLIST_FILE = "Examples/Examples-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;

--- a/Examples/Examples/ESTViewController.m
+++ b/Examples/Examples/ESTViewController.m
@@ -36,6 +36,10 @@
 
 @end
 
+@interface ESTViewController()
+@property (nonatomic, retain) CLLocationManager *locationManager;
+@end
+
 @implementation ESTViewController
 
 - (void)viewDidLoad
@@ -58,6 +62,9 @@
     self.beaconDemoList = @[ @[@"Distance Demo", @"Proximity Demo",@"Notification Demo"],
                              @[@"Temperature Demo", @"Accelerometer Demo"],
                              @[@"Update Firmware Demo", @"My beacons in Cloud Demo"]];
+    
+    self.locationManager = [[CLLocationManager alloc] init];
+    [self.locationManager requestAlwaysAuthorization];
 }
 
 -(void)authorizeBtnTapped:(UIButton *)button

--- a/Examples/Examples/Examples-Info.plist
+++ b/Examples/Examples/Examples-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Allow Examples to access your location to track iBeacons.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
- Fix build error caused by tests referencing non-existant plist file
- Request authorization prior to using location services
